### PR TITLE
feat: implement modes REGENB and START

### DIFF
--- a/src/mode_logic.c
+++ b/src/mode_logic.c
@@ -56,7 +56,38 @@ void ModeLogic_Step(State_t* state, Inputs_t* in, Outputs_t* out)
             break;
 
         case MODE_REGENB:
+            if (in->speed <= SPEED_STOP) {
+                state->current_mode = MODE_STANDSTILL;
+            } else if (((in->speed > SPEED_EV_MAX) && (in->P_dem >= PDEM_STOP_LOW)) ||
+                       (in->P_dem >= PDEM_HYB_IN) ||
+                       (in->SOC < SOC_EV_OUT)) {
+                state->current_mode = MODE_START;
+            } else if ((in->P_dem >= PDEM_STOP_LOW) &&
+                       (in->speed > SPEED_STOP) &&
+                       (in->speed <= SPEED_EV_MAX) &&
+                       (in->SOC > SOC_EV_IN)) {
+                state->current_mode = MODE_EV;
+            }
+
+            out->Mot_Enable = 1;
+            out->Gen_Enable = 0;
+            out->ICE_Enable = 0;
+            break;
+
         case MODE_START:
+            if ((in->wEng > ENG_ON) && (in->SOC < SOC_LOW)) {
+                state->current_mode = MODE_ICE;
+            } else if ((in->wEng > ENG_ON) &&
+                       ((in->P_dem >= PDEM_HYB_IN) || (in->speed > SPEED_EV_MAX)) &&
+                       (in->SOC >= SOC_LOW)) {
+                state->current_mode = MODE_HYBRID;
+            }
+
+            out->Mot_Enable = 1;
+            out->Gen_Enable = 1;
+            out->ICE_Enable = 0;
+            break;
+
         case MODE_ICE:
         case MODE_HYBRID:
         default:


### PR DESCRIPTION
Implementation of state logic in the mode_logic.c file, covering MODE_REGEN and MODE_START along with their respective transition and exit rules according to SwHLR05 and SwHLR06 requirements.

Closes #23.