### PR TITLE
hotfix(hybrid-ice): adjust exit rules for boundary values

### DIFF
--- a/src/mode_logic_team.c
+++ b/src/mode_logic_team.c
@@ -177,11 +177,11 @@ static Mode_t motion_ice_common_exit(const Inputs_t *in, Mode_t current_in_block
                (in->P_dem >= PDEM_STOP_LOW) &&
                (in->speed > SPEED_STOP) &&
                (in->speed <= SPEED_EV_MAX) &&
-               (in->SOC > SOC_EV_IN)) {
+               (in->SOC >= SOC_EV_IN)) {
         next = MODE_EV;
     } else if ((in->speed <= SPEED_STOP) &&
-               (in->P_dem < PDEM_STOP_HIGH) &&
-               (in->P_dem > PDEM_STOP_LOW)) {
+               (in->P_dem <= PDEM_STOP_HIGH) &&
+               (in->P_dem >= PDEM_STOP_LOW)) {
         next = MODE_STANDSTILL;
     } else {
         /* continua no bloco interno atual */

--- a/src/mode_logic_team_P_A_B_update.c
+++ b/src/mode_logic_team_P_A_B_update.c
@@ -175,11 +175,11 @@ static Mode_t motion_ice_common_exit(const Inputs_t *in, Mode_t current_in_block
                (in->P_dem >= PDEM_STOP_LOW) &&
                (in->speed > SPEED_STOP) &&
                (in->speed <= SPEED_EV_MAX) &&
-               (in->SOC > SOC_EV_IN)) {
+               (in->SOC >= SOC_EV_IN)) {
         next = MODE_EV;
     } else if ((in->speed <= SPEED_STOP) &&
-               (in->P_dem < PDEM_STOP_HIGH) &&
-               (in->P_dem > PDEM_STOP_LOW)) {
+               (in->P_dem <= PDEM_STOP_HIGH) &&
+               (in->P_dem >= PDEM_STOP_LOW)) {
         next = MODE_STANDSTILL;
     } else {
         /* continua no bloco interno atual */


### PR DESCRIPTION
## Summary
This PR fixes the Hybrid ICE exit rules to correctly handle boundary values in transition conditions.

## What changed
- Updated the EV transition condition from `SOC > SOC_EV_IN` to `SOC >= SOC_EV_IN`
- Updated the standstill transition condition to include boundary values:
  - `P_dem <= PDEM_STOP_HIGH`
  - `P_dem >= PDEM_STOP_LOW`
- Applied the same fix in both mode logic implementations to keep behavior consistent

## Why
Previously, exact threshold values were excluded from the transition logic. This could cause the state machine to remain in the current internal mode when `SOC` or `P_dem` matched the configured limits exactly.

## Impact
- Fixes edge cases in Hybrid ICE exit behavior
- Makes transition logic consistent for threshold equality cases
- Reduces the chance of unexpected mode retention at limit values

## Validation
- Verified the change in both affected source files
- No automated tests were run
