### PR TITLE
fix(ci): align workflow with refactored sources and tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,17 +20,19 @@ jobs:
 
       - name: Run MISRA C 2012 analysis
         run: |
+          set +e
           cppcheck --enable=all \
                    --suppress=missingIncludeSystem \
                    --inline-suppr \
                    --addon=misra \
                    --error-exitcode=1 \
                    --output-file=cppcheck-report.txt \
-                   --xml \
                    -Iinc \
                    src/ inc/
+          STATUS=$?
           echo "=== MISRA C 2012 Analysis Report ==="
-          cat cppcheck-report.txt
+          cat cppcheck-report.txt || true
+          exit $STATUS
 
       - name: Upload analysis report
         if: always()
@@ -61,9 +63,12 @@ jobs:
                    test/test_standstill_transitions.c \
                    test/test_start_to_hybrid_ice_and_resets.c \
                    test/test_ice_hybrid_external_and_internal.c; do
+            echo "=== Generating runner for $t ==="
+            runner="${t%.c}_runner.c"
+            ruby unity/auto/generate_test_runner.rb "$t" "$runner"
             echo "=== Building $t ==="
             gcc -std=c99 -Wall -Wextra -Iinc -Iunity/src \
-                src/mode_logic_team.c unity/src/unity.c "$t" \
+                src/mode_logic_team.c unity/src/unity.c "$t" "$runner" \
                 -o test_runner
             echo "=== Running $t ==="
             ./test_runner

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,26 @@ jobs:
       - name: Install cppcheck
         run: sudo apt-get update && sudo apt-get install -y cppcheck
 
+      - name: Diagnose cppcheck environment
+        run: |
+          set +e
+          echo "=== cppcheck version ==="
+          cppcheck --version
+          echo "=== which cppcheck / addons dir ==="
+          which cppcheck
+          ls -la /usr/share/cppcheck/addons/ || true
+          echo "=== python3 version ==="
+          python3 --version
+          echo "=== try running misra.py addon directly ==="
+          python3 /usr/share/cppcheck/addons/misra.py --help 2>&1 || true
+          echo "=== try generating a dump and running misra.py on it ==="
+          cppcheck --dump -Iinc src/mode_logic_team.c 2>&1 || true
+          ls -la src/*.dump 2>&1 || true
+          if [ -f src/mode_logic_team.c.dump ]; then
+            python3 /usr/share/cppcheck/addons/misra.py src/mode_logic_team.c.dump 2>&1 || true
+          fi
+          echo "=== end of diagnostics ==="
+
       - name: Run MISRA C 2012 analysis
         run: |
           set +e

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
           set +e
           cppcheck --enable=all \
                    --suppress=missingIncludeSystem \
+                   --suppress=unmatchedSuppression \
                    --inline-suppr \
                    --error-exitcode=1 \
                    --output-file=cppcheck-report.txt \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,25 +18,16 @@ jobs:
       - name: Install cppcheck
         run: sudo apt-get update && sudo apt-get install -y cppcheck
 
-      - name: Diagnose cppcheck environment
+      - name: Install cppcheck addons (apt package omits them)
         run: |
-          set +e
-          echo "=== cppcheck version ==="
-          cppcheck --version
-          echo "=== which cppcheck / addons dir ==="
-          which cppcheck
-          ls -la /usr/share/cppcheck/addons/ || true
-          echo "=== python3 version ==="
-          python3 --version
-          echo "=== try running misra.py addon directly ==="
-          python3 /usr/share/cppcheck/addons/misra.py --help 2>&1 || true
-          echo "=== try generating a dump and running misra.py on it ==="
-          cppcheck --dump -Iinc src/mode_logic_team.c 2>&1 || true
-          ls -la src/*.dump 2>&1 || true
-          if [ -f src/mode_logic_team.c.dump ]; then
-            python3 /usr/share/cppcheck/addons/misra.py src/mode_logic_team.c.dump 2>&1 || true
-          fi
-          echo "=== end of diagnostics ==="
+          set -e
+          CPPCHECK_VERSION=$(cppcheck --version | awk '{print $2}')
+          echo "Fetching addons matching cppcheck $CPPCHECK_VERSION"
+          git clone --depth 1 --branch "$CPPCHECK_VERSION" \
+            https://github.com/danmar/cppcheck.git /tmp/cppcheck-src
+          sudo mkdir -p /usr/share/cppcheck/addons
+          sudo cp /tmp/cppcheck-src/addons/*.py /usr/share/cppcheck/addons/
+          ls -la /usr/share/cppcheck/addons/
 
       - name: Run MISRA C 2012 analysis
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,21 +29,37 @@ jobs:
           sudo cp /tmp/cppcheck-src/addons/*.py /usr/share/cppcheck/addons/
           ls -la /usr/share/cppcheck/addons/
 
-      - name: Run MISRA C 2012 analysis
+      - name: Run cppcheck general checks
         run: |
           set +e
           cppcheck --enable=all \
                    --suppress=missingIncludeSystem \
                    --inline-suppr \
-                   --addon=misra \
                    --error-exitcode=1 \
                    --output-file=cppcheck-report.txt \
                    -Iinc \
                    src/ inc/
           STATUS=$?
-          echo "=== MISRA C 2012 Analysis Report ==="
+          echo "=== cppcheck general report ==="
           cat cppcheck-report.txt || true
           exit $STATUS
+
+      - name: Run MISRA C 2012 (manual dump + addon)
+        run: |
+          set +e
+          echo "=== generating cppcheck dumps ==="
+          cppcheck --dump -Iinc src/ inc/
+          echo "=== running misra.py on each dump ==="
+          MISRA_STATUS=0
+          for f in $(find src inc -name '*.dump'); do
+            echo "--- $f ---"
+            python3 /usr/share/cppcheck/addons/misra.py "$f"
+            rc=$?
+            if [ "$rc" != "0" ]; then
+              MISRA_STATUS=$rc
+            fi
+          done
+          exit $MISRA_STATUS
 
       - name: Upload analysis report
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
                    --output-file=cppcheck-report.txt \
                    --xml \
                    -Iinc \
-                   src/ inc/ test/
+                   src/ inc/
           echo "=== MISRA C 2012 Analysis Report ==="
           cat cppcheck-report.txt
 
@@ -50,8 +50,21 @@ jobs:
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y build-essential
 
+      - name: Fetch Unity
+        run: git clone --depth 1 https://github.com/ThrowTheSwitch/Unity.git unity
+
       - name: Build and run mode logic tests
         run: |
-          gcc -Wall -Wextra -Werror -Iinc -o test_mode_logic src/mode_logic.c test/test_mode_logic.c
-          ./test_mode_logic
-
+          set -e
+          for t in test/test_ev_transitions.c \
+                   test/test_regenb_transitions.c \
+                   test/test_standstill_transitions.c \
+                   test/test_start_to_hybrid_ice_and_resets.c \
+                   test/test_ice_hybrid_external_and_internal.c; do
+            echo "=== Building $t ==="
+            gcc -std=c99 -Wall -Wextra -Iinc -Iunity/src \
+                src/mode_logic_team.c unity/src/unity.c "$t" \
+                -o test_runner
+            echo "=== Running $t ==="
+            ./test_runner
+          done

--- a/cppcheck-report.txt
+++ b/cppcheck-report.txt
@@ -1,0 +1,17 @@
+src\mode_logic_team.c:257:12: style: The scope of the variable 'next' can be reduced. [variableScope]
+    Mode_t next;
+           ^
+src\mode_logic_team.c:247:6: style: The function 'ModeLogic_Init' is never used. [unusedFunction]
+void ModeLogic_Init(State_t *state)
+     ^
+src\mode_logic_team.c:255:6: style: The function 'ModeLogic_Step' is never used. [unusedFunction]
+void ModeLogic_Step(State_t *state, const Inputs_t *in, Outputs_t *out)
+     ^
+src\mode_logic_team.c:247:6: style: misra violation (use --rule-texts=<file> to get proper output) [misra-c2012-8.7]
+void ModeLogic_Init(State_t *state)
+     ^
+src\mode_logic_team.c:255:6: style: misra violation (use --rule-texts=<file> to get proper output) [misra-c2012-8.7]
+void ModeLogic_Step(State_t *state, const Inputs_t *in, Outputs_t *out)
+     ^
+nofile:0:0: information: Active checkers: 268/386 (use --checkers-report=<filename> to see details) [checkersReport]
+

--- a/src/mode_logic_team.c
+++ b/src/mode_logic_team.c
@@ -244,6 +244,9 @@ static void write_outputs(Mode_t mode, Outputs_t *out)
     }
 }
 
+/* Public API consumed by test/ and external clients */
+/* cppcheck-suppress misra-c2012-8.7 */
+/* cppcheck-suppress unusedFunction */
 void ModeLogic_Init(State_t *state)
 {
     if (state != NULL) {
@@ -252,12 +255,13 @@ void ModeLogic_Init(State_t *state)
     }
 }
 
+/* Public API consumed by test/ and external clients */
+/* cppcheck-suppress misra-c2012-8.7 */
+/* cppcheck-suppress unusedFunction */
 void ModeLogic_Step(State_t *state, const Inputs_t *in, Outputs_t *out)
 {
-    Mode_t next;
-
     if ((state != NULL) && (in != NULL) && (out != NULL)) {
-        next = state->current_mode;
+        Mode_t next = state->current_mode;
 
         switch (state->current_mode) {
             case MODE_STANDSTILL:


### PR DESCRIPTION

## Summary

Fix CI failures introduced after the v1.0.0 merge. Both jobs (`Static Analysis` and `Build and test`) were broken because the workflow still referenced deleted sources/tests, the Unity test framework wasn't being fetched, and the cppcheck MISRA addon was misconfigured for the Ubuntu runner.

## Changes

### `.github/workflows/ci.yaml`
- **Restrict MISRA scope** to `src/` and `inc/` (removed `test/` — Unity macros and test patterns are not meant to be MISRA-compliant).
- **Fetch Unity** in the build job and **generate test runners** automatically with `unity/auto/generate_test_runner.rb` for each transition-oriented test file. Replaces the stale references to `src/mode_logic.c` and `test/test_mode_logic.c` (both deleted in v1.0.0).
- **Install cppcheck addons from upstream source**, matching the apt-installed version — the Ubuntu `cppcheck` package omits `/usr/share/cppcheck/addons/`, which made `--addon=misra` fail with the opaque `Failed to execute addon 'misra' - exitcode is 1`.
- **Split static analysis into two steps**: cppcheck general checks (`--enable=all`) and a manual MISRA pass (`cppcheck --dump` + `python3 misra.py`). Surfaces real Python tracebacks if the addon ever crashes again instead of hiding them behind cppcheck's wrapper.
- **Suppress `unmatchedSuppression`** in the general step (the inline MISRA suppressions only resolve in the dedicated MISRA step).
- Always print the cppcheck report before propagating the exit code, so violations are visible in the log on failure.

### `src/mode_logic_team.c`
- Add inline cppcheck suppressions for `misra-c2012-8.7` and `unusedFunction` on `ModeLogic_Init` and `ModeLogic_Step`. **Both are false positives**: the functions are the module's public API, consumed by tests and external clients, so they cannot be `static` and are not actually unused.
- Move `Mode_t next` declaration into the `if ((state != NULL) && (in != NULL) && (out != NULL))` block in `ModeLogic_Step` (resolves `variableScope`). Behavior is identical — `next` was already only read/written inside that block.

## Why

After v1.0.0 the CI was completely red. Each iteration uncovered a different layer of the problem:
1. `src/mode_logic.c` and `test/test_mode_logic.c` no longer existed.
2. Unity tests had no `main()` because runners are generated, not committed.
3. The Ubuntu `cppcheck` package doesn't ship the Python addons.
4. The cppcheck wrapper hides addon-internal errors behind a generic exit code.
5. cppcheck flags `unmatchedSuppression` as `information`, which `--error-exitcode=1` propagates as a build failure.

This PR addresses each layer end-to-end, with the static analysis split designed to make any future addon failure debuggable instead of opaque.

## Checklist
- [x] `Build and test` green (Unity runners generated, all 5 transition suites compile and run).
- [x] `Static Analysis` green (general checks + MISRA addon pass cleanly with the documented suppressions).
- [x] No changes to test code or production logic — only build/CI plumbing and inline suppressions.
- [x] Inline suppressions document the reason in-place (public API consumed by `test/` and external clients).